### PR TITLE
add fields key to post , put and  patch

### DIFF
--- a/src/Api/AirtableApiClient.php
+++ b/src/Api/AirtableApiClient.php
@@ -60,7 +60,7 @@ class AirtableApiClient implements ApiClient
     {
         $url = $this->getEndpointUrl();
 
-        $params = ['json' => ['fields' => (object)$contents]];
+        $params = ['json' => ['fields' => (object) $contents]];
 
         return $this->jsonToObject($this->client->post($url, $params));
     }
@@ -69,7 +69,7 @@ class AirtableApiClient implements ApiClient
     {
         $url = $this->getEndpointUrl($id);
 
-        $params = ['json' => ['fields' => (object)$contents]];
+        $params = ['json' => ['fields' => (object) $contents]];
 
         return $this->jsonToObject($this->client->put($url, $params));
     }
@@ -78,7 +78,7 @@ class AirtableApiClient implements ApiClient
     {
         $url = $this->getEndpointUrl($id);
 
-        $params = ['json' => ['fields' => (object)$contents]];
+        $params = ['json' => ['fields' => (object) $contents]];
 
         return $this->jsonToObject($this->client->patch($url, $params));
     }

--- a/src/Api/AirtableApiClient.php
+++ b/src/Api/AirtableApiClient.php
@@ -60,7 +60,7 @@ class AirtableApiClient implements ApiClient
     {
         $url = $this->getEndpointUrl();
 
-        $params = $contents === null ? ['body' => ''] : ['json' => $contents];
+        $params = ['json' => ['fields' => (object)$contents]];
 
         return $this->jsonToObject($this->client->post($url, $params));
     }
@@ -69,7 +69,7 @@ class AirtableApiClient implements ApiClient
     {
         $url = $this->getEndpointUrl($id);
 
-        $params = $contents === null ? ['body' => ''] : ['json' => $contents];
+        $params = ['json' => ['fields' => (object)$contents]];
 
         return $this->jsonToObject($this->client->put($url, $params));
     }
@@ -78,7 +78,7 @@ class AirtableApiClient implements ApiClient
     {
         $url = $this->getEndpointUrl($id);
 
-        $params = $contents === null ? ['body' => ''] : ['json' => $contents];
+        $params = ['json' => ['fields' => (object)$contents]];
 
         return $this->jsonToObject($this->client->patch($url, $params));
     }


### PR DESCRIPTION
we can now create update a record with sending array of fields and you can create empty records as api documentation.
```php
     \Airtable::table('default')->create( ['name' => 'mohamed']);
     // or empty record
     \Airtable::table('default')->create(null);
     // or with stdclass object
     \Airtable::table('users')->create($user);
```